### PR TITLE
homepage: remove link to rust-users crate

### DIFF
--- a/homepage/index.html
+++ b/homepage/index.html
@@ -306,9 +306,6 @@
             <li>
               <a href="https://github.com/uutils/uutils-term-grid">uutils-term-grid</a>
             </li>
-            <li>
-              <a href="https://github.com/uutils/rust-users">rust-users</a>
-            </li>
           </ul>
           <h2>Contributing</h2>
           <p>You can help us out by:</p>


### PR DESCRIPTION
This PR removes the link to the `rust-users` crate because it seems like we don't use it.