### PR TITLE
ci: use dtolnay/rust-toolchain instead of action-rs/toolchain

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,11 +37,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install `rust` toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        default: true
-        profile: minimal
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Install `libacl`
       run: |


### PR DESCRIPTION
This PR replaces the unmaintained `action-rs/toolchain` with `dtolnay/rust-toolchain` go get rid of some CI warnings. See https://github.com/actions-rs/toolchain/issues/221 for a discussion