### PR TITLE
Remove dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 5


### PR DESCRIPTION
This PR removes the `dependabot` config file because it doesn't make sense to use both `dependabot` and `renovate`.