### PR TITLE
config.toml: remove `paginate_by` entry, fix typo

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,9 +7,7 @@ description = ""
 
 default_language = "en"
 
-paginate_by = 10
-
-generate_feed = true
+generate_feeds = true
 
 [markdown]
 highlight_code = true


### PR DESCRIPTION
This PR removes the `paginate_by` entry in `config.toml` and changes the `generate_feed` key to `generate_feeds`. Both caused "unknown field" errors when compiling.