### PR TITLE
Fix links on mobile layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -382,6 +382,7 @@ blockquote {
 
 .links {
   display: flex;
+  flex-wrap: wrap;
   justify-content: stretch;
   gap: 1em;
   margin-bottom: 2em;


### PR DESCRIPTION
Hello, this is a very small fix on the links layout adding `wrap` css property.

Before :

<img width="200" alt="Capture d’écran 2025-02-16 à 19 54 55" src="https://github.com/user-attachments/assets/1c7d5802-d9e5-4dee-b84e-edcb05d2125d" /> <img width="200" alt="Capture d’écran 2025-02-16 à 19 55 01" src="https://github.com/user-attachments/assets/2c892200-449c-4857-81d4-38ef30154907" />

After :

<img width="432" alt="Capture d’écran 2025-02-16 à 19 54 28" src="https://github.com/user-attachments/assets/a1ac81ae-62f2-4deb-a8e5-7f023d14780b" />
