### PR TITLE
Hide `true` and `false` from the playground command list

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -143,7 +143,7 @@ jobs:
           # HIDDEN_CMDS: utilities that ship in the binary but we don't want to
           # advertise in the playground (e.g. `yes` produces infinite output
           # that just spams the terminal).
-          HIDDEN_CMDS='^(yes)$'
+          HIDDEN_CMDS='^(false|true|yes)$'
           commands=$(sed -n '/^feat_wasm = \[/,/^\]/p' Cargo.toml \
             | grep -oE '"[a-zA-Z0-9_]+"' | tr -d '"' \
             | sort -u | grep -vE "$HIDDEN_CMDS" | paste -sd, -)


### PR DESCRIPTION
Context: https://github.com/uutils/coreutils/issues/12438

`true` and `false` ship in the WASM binary, but are not a useful demonstration because they produce no output and there is no facility to check exit code in the playground.