### PR TITLE
fix: nixpkgs wiki link

### DIFF
--- a/content/users.md
+++ b/content/users.md
@@ -205,7 +205,7 @@ uutils coreutils is available in **nixpkgs** as `uutils-coreutils` and
 prefix, as drop-in replacements).
 
 **Links:**
-- [NixOS Wiki: uutils coreutils](https://wiki.nixos.org/wiki/Uutils_coreutils)
+- [NixOS Wiki: Uutils](https://wiki.nixos.org/wiki/Uutils)
 
 ---
 


### PR DESCRIPTION
Simply fixing the nixpkgs wiki link 

_I'm also the [creator of the Uutils page on Nix wiki](https://wiki.nixos.org/w/index.php?title=Uutils&oldid=24098), more on this [here](https://discourse.nixos.org/t/what-do-you-think-about-replacing-gnu-core-utils-with-uutils-by-default-in-nixos/61797/16?u=malix)_